### PR TITLE
Update Dockerfile CMD to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-CMD python src/main.py
+CMD python3 src/main.py


### PR DESCRIPTION
Newer Pi builds require python3 to launch properly.